### PR TITLE
fix: pass both range values to firstScan/nextScan for between scans

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -3838,9 +3838,16 @@ function cmd_persistent_scan_first_scan(params)
     local scanOpt   = resolveScanOption(scan_option)
 
     local fsOk, fsMsg = pcall(function()
-        ms.firstScan(scanOpt, varType, rtRounded, tostring(value), nil,
-                     0, 0x7FFFFFFFFFFFFFFF, "+W-C", fsmNotAligned, "1",
-                     false, false, false, false)
+        if scanOpt == soValueBetween and value and string.find(value, ";") then
+            local v1, v2 = string.match(value, "^(.-);(.-)$")
+            ms.firstScan(scanOpt, varType, rtRounded, v1, v2,
+                         0, 0x7FFFFFFFFFFFFFFF, "+W-C", fsmNotAligned, "1",
+                         false, false, false, false)
+        else
+            ms.firstScan(scanOpt, varType, rtRounded, tostring(value), nil,
+                         0, 0x7FFFFFFFFFFFFFFF, "+W-C", fsmNotAligned, "1",
+                         false, false, false, false)
+        end
         ms.waitTillDone()
     end)
     if not fsOk then
@@ -3885,7 +3892,10 @@ function cmd_persistent_scan_next_scan(params)
     local scanOpt = resolveScanOption(scan_option)
 
     local nsOk, nsMsg = pcall(function()
-        if scanOpt == soExactValue or scanOpt == soValueBetween or scanOpt == soBiggerThan or scanOpt == soSmallerThan then
+        if scanOpt == soValueBetween and value and string.find(value, ";") then
+            local v1, v2 = string.match(value, "^(.-);(.-)$")
+            ms.nextScan(scanOpt, rtRounded, v1, v2, false, false, false, false, false)
+        elseif scanOpt == soExactValue or scanOpt == soValueBetween or scanOpt == soBiggerThan or scanOpt == soSmallerThan then
             ms.nextScan(scanOpt, rtRounded, tostring(value or ""), nil, false, false, false, false, false)
         else
             ms.nextScan(scanOpt, rtRounded, nil, nil, false, false, false, false, false)


### PR DESCRIPTION
## Problem

cmd_persistent_scan_first_scan and cmd_persistent_scan_next_scan always pass 
il as the second value to CE's firstScan/nextScan:

```lua
ms.firstScan(scanOpt, varType, rtRounded, tostring(value), nil, ...)
```

CE's range-scan option soValueBetween requires two endpoint values (value1, value2). Because value2 was hard-coded to nil, every between scan returned 0 results, making the between scan option unusable through the MCP bridge.

## Fix

When scan_option is "between" and value contains a ";" separator (e.g. "80;90"), split into v1/v2 and pass both to CE:

- firstScan: ms.firstScan(soValueBetween, varType, rtRounded, v1, v2, ...)
- nextScan: ms.nextScan(soValueBetween, rtRounded, v1, v2, ...)

Other scan options keep existing behaviour.

## Usage

persistent_scan_first_scan(scan_option="between", value="80;90", type="float")

## Verification

- Before: between 80;90 float -> count: 0
- After: same call -> count: 2306880
- exact/increased/decreased/bigger/smaller regression-checked
- Tested against Patrician IV (32-bit) with Cheat Engine 7.6